### PR TITLE
Catch BadImageFormatException in ArgFinder

### DIFF
--- a/Source/Danio/Internal/ArgFinder.cs
+++ b/Source/Danio/Internal/ArgFinder.cs
@@ -48,6 +48,10 @@
                     {
                         warningLog.Add("Could not find DLL [{0}] with exception: [{1}]", childName, e);
                     }
+                    catch (BadImageFormatException e)
+                    {
+                        warningLog.Add("Unable to load DLL [{0}] with exception: [{1}]", childName, e);
+                    }
                 }
 
                 Type[] currentAssemblyTypes = null;


### PR DESCRIPTION
Fixing #1.

According to the [documentation](https://msdn.microsoft.com/en-us/library/x4cw969y(v=vs.110).aspx) these are all exceptions that can be thrown. 